### PR TITLE
fixed preimage outpoint bug, support empty string 

### DIFF
--- a/src/scryptTypes.ts
+++ b/src/scryptTypes.ts
@@ -183,7 +183,7 @@ export class SigHashType extends ScryptType {
 
 }
 
-interface Outpoint { hash: string, index: number }
+interface Outpoint { hash: string, index: number, hex: string }
 
 export class SigHashPreimage extends ScryptType {
 
@@ -216,9 +216,14 @@ export class SigHashPreimage extends ScryptType {
 
 	// outpoint
 	get outpoint(): Outpoint {
+    const buf = this._buf.slice(68, 68 + 32 + 4);
+    const hex = buf.toString('hex');
+    const index = this.getReader(buf.slice(32, 32 + 4)).readUInt32LE();
+    const hash = Buffer.from(buf.slice(0, 32)).reverse().toString('hex');
 		return {
-			hash: this._buf.slice(68, 68 + 32).toString('hex'),
-			index: this.getReader(this._buf.slice(68 + 32, 68 + 32 + 4)).readUInt32LE()
+			hash,
+      index,
+      hex
 		};
 	}
 

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -20,6 +20,9 @@ function serializeInt(n: number | bigint): string {
 }
 
 function serializeString (str: string) {
+  if (str==='') {
+    return '00';
+  }
   const buf = Buffer.from(str, 'utf8');
   return buf.toString( 'hex' );
 }
@@ -122,7 +125,10 @@ class OpState {
 
   toString ( arg = 'utf8') {
     if (!this.op.buf) { throw new Error('state does not have a string representation'); }
-    return this.op.buf.toString( arg ).trim();
+    if (this.op.buf[0] === 0) {
+      return '';
+    }
+    return this.op.buf.toString( arg );
   }
 }
 

--- a/test/preimage.test.ts
+++ b/test/preimage.test.ts
@@ -1,0 +1,38 @@
+import { expect } from 'chai'
+import { loadDescription, newTx } from './helper'
+import { buildContractClass } from '../src/contract'
+import { bsv, toHex, getPreimage, } from '../src/utils'
+import { SigHashPreimage, Ripemd160 } from '../src/scryptTypes'
+
+const privateKey = new bsv.PrivateKey.fromRandom('testnet')
+const publicKey = privateKey.publicKey
+const pubKeyHash = bsv.crypto.Hash.sha256ripemd160(publicKey.toBuffer())
+const inputSatoshis = 100000
+const tx = newTx(inputSatoshis)
+
+const jsonDescr = loadDescription('p2pkh.scrypt')
+const DemoP2PKH = buildContractClass(jsonDescr)
+const p2pkh = new DemoP2PKH(new Ripemd160(toHex(pubKeyHash)))
+
+describe('Preimage', () => {
+  describe('check preimage parts', () => {
+    let preimage: SigHashPreimage
+
+    before(() => {
+      preimage = getPreimage(tx, p2pkh.lockingScript.toASM(), inputSatoshis, 0)
+    })
+
+    it('outpoint', () => {
+      const outpoint = preimage.outpoint
+      expect(outpoint.hash).is.eq('a477af6b2667c29670467e4e0728b685ee07b240235771862318e29ddbe58458')
+      expect(outpoint.index).is.eq(0)
+      expect(outpoint.hex).is.eq('5884e5db9de218238671572340b207ee85b628074e7e467096c267266baf77a400000000')
+    })
+
+    it('scriptCode', () => {
+      const scriptCode = preimage.scriptCode
+      const hex = p2pkh.lockingScript.toHex()
+      expect(scriptCode).is.eq((hex.length/2).toString(16) + hex)
+    })
+  })
+})

--- a/test/serializer.test.ts
+++ b/test/serializer.test.ts
@@ -104,6 +104,18 @@ describe('serializer', () => {
       expect(hex).to.equal('004f51011102123451020900')
     })
 
+    it('special string with schema', () => {
+      const schema = ['string', 'string', 'string', 'string' ]
+      //emptr, space, double space, UTF8 Full-Word Space
+      const state = ['', ' ', '  ', '　' ]
+      const serial = serializeState(state, STATE_LEN_2BYTES, schema )
+      const script = Script.fromASM(serial)
+      const hex = script.toHex()
+
+      expect(serial).to.equal('00 20 2020 e38080 0b00')
+      expect(hex).to.equal('0100012002202003e38080020b00')
+    })
+
     it('negative number', () => {
       const state = [-100]
       const serial = serializeState(state)
@@ -360,6 +372,21 @@ describe('serializer', () => {
       for(let i=0; i<states.length; i++) {
         expect(deStates[i].toNumber()).to.equal(i)
       }
+    })
+
+    it('special string with schema', () => {
+      const schema = ['string', 'string', 'string', 'string', 'string' ]
+      //emptr, space, double space, UTF8 Full-Word Space, string with left & right space
+      const states = ['', ' ', '  ', '　', '  hello   ' ]
+      const serial = serializeState(states, STATE_LEN_2BYTES, schema )
+      const script = Script.fromASM(serial)
+      const hex = script.toHex()
+
+      expect(serial).to.equal('00 20 2020 e38080 202068656c6c6f202020 1600')
+      expect(hex).to.equal('0100012002202003e380800a202068656c6c6f202020021600')
+
+      const deStates = deserializeState(hex, schema)
+      expect(deStates).to.eql(states)
     })
 
     it('negative number', () => {


### PR DESCRIPTION
- fixed preimage outpoint bug, add test case.  the outpoint hash must be reversed
- support empty string serializer
