### PR TITLE
Add chalk as explicit dependency. Version bump 2.1.39.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "eslint.validate": [
         "typescript",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "scryptlib",
-  "version": "2.1.38",
+  "version": "2.1.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scryptlib",
-      "version": "2.1.38",
+      "version": "2.1.39",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.7",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "bsv": "^1.5.6",
+        "chalk": "2.4.2",
         "compare-versions": "^3.6.0",
         "find-node-modules": "^2.1.3",
         "get-proxy-settings": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scryptlib",
-  "version": "2.1.38",
+  "version": "2.1.39",
   "description": "Javascript SDK for integration of Bitcoin SV Smart Contracts written in sCrypt language.",
   "engines": {
     "node": ">=14.0.0"
@@ -73,6 +73,7 @@
     "node-fetch": "^3.0.0",
     "patch-package": "^6.4.7",
     "rimraf": "^3.0.2",
-    "yargs": "^17.6.2"
+    "yargs": "^17.6.2",
+    "chalk": "2.4.2"
   }
 }


### PR DESCRIPTION
Added 'chalk' as an explicit dependency to stop Yarn from complaining:

```
# This file contains the result of Yarn building a package (scryptlib@npm:2.1.38)
# Script name: postinstall

/home/miha/Work/tokenovate/smart-contract-development/.pnp.cjs:15034
      Error.captureStackTrace(firstError);
            ^

Error: scryptlib tried to access chalk, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: chalk
Required by: scryptlib@npm:2.1.38 (via /home/miha/Work/tokenovate/smart-contract-development/.yarn/unplugged/scryptlib-npm-2.1.38-6fbde13c80/node_modules/scryptlib/patches/)

Require stack:
- /home/miha/Work/tokenovate/smart-contract-development/.yarn/unplugged/scryptlib-npm-2.1.38-6fbde13c80/node_modules/scryptlib/patches/applyPatch.js
- /home/miha/Work/tokenovate/smart-contract-development/.yarn/unplugged/scryptlib-npm-2.1.38-6fbde13c80/node_modules/scryptlib/postinstall.js
    at require$$0.Module._resolveFilename (/home/miha/Work/tokenovate/smart-contract-development/.pnp.cjs:15034:13)
    at Module._load (node:internal/modules/cjs/loader:975:27)
    at require$$0.Module._load (/home/miha/Work/tokenovate/smart-contract-development/.pnp.cjs:14925:31)
    at Module.require (node:internal/modules/cjs/loader:1225:19)
    at require (node:internal/modules/helpers:177:18)
    at Object.<anonymous> (/home/miha/Work/tokenovate/smart-contract-development/.yarn/unplugged/scryptlib-npm-2.1.38-6fbde13c80/node_modules/scryptlib/patches/applyPatch.js:4:15)
    at Module._compile (node:internal/modules/cjs/loader:1356:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
    at require$$0.Module._extensions..js (/home/miha/Work/tokenovate/smart-contract-development/.pnp.cjs:15077:33)
    at Module.load (node:internal/modules/cjs/loader:1197:32)

Node.js v18.19.0
```